### PR TITLE
Add ability to exclude paths and hide debug tab

### DIFF
--- a/source/SnapshotBTRFS.page
+++ b/source/SnapshotBTRFS.page
@@ -197,7 +197,7 @@ $(function(){
 		});
 	}
 
-		function run_schedule(subvol, slot) {
+	function run_schedule(subvol, slot) {
 		/* add spinning and disable button */
 
 	
@@ -247,12 +247,13 @@ function removeSnapshot() {
 	{
 		/* save table widths */
 
-	//var document_tab = get_tab_title_by_name("tab_snaps") ;
-	//var hideroot = document.getElementById("root-swt") ;
-	hideroot = $.cookie('SNAP-root-view') ;
-	hidedocker = $.cookie('SNAP-docker-view') ;
+		//var document_tab = get_tab_title_by_name("tab_snaps") ;
+		//var hideroot = document.getElementById("root-swt") ;
+		hideroot = $.cookie('SNAP-root-view') ;
+		hidedocker = $.cookie('SNAP-docker-view') ;
+		hideexcluded = $.cookie('SNAP-exclude-view') ;
 	
-		$.post(SNAPURL,{table:"sv2", hideroot:hideroot, hidedocker:hidedocker},function(data)
+		$.post(SNAPURL,{table:"sv2", hideroot:hideroot, hidedocker:hidedocker, hideexcluded:hideexcluded},function(data)
 		{
 			maxWidth = [];
 			var toggled = $("tr.toggle-parts").filter(":visible").map(function(){return $(this).attr("name");}).get();
@@ -527,11 +528,15 @@ function removeSnapshot() {
 		$(this).css("display", $(".root-switch").is(":checked") ? "block" : "none");
 	});
 
-		$( "#SnapBTRFS" ).arrive(".show-docker", {onceOnly:false}, function()
+	$( "#SnapBTRFS" ).arrive(".show-docker", {onceOnly:false}, function()
 	{
 		$(this).css("display", $(".docker-switch").is(":checked") ? "block" : "none");
 	});
 
+	$( "#SnapBTRFS" ).arrive(".show-exclude", {onceOnly:false}, function()
+	{
+		$(this).css("display", $(".exclude-switch").is(":checked") ? "block" : "none");
+	});
 
 	$(function()
 	{
@@ -548,9 +553,7 @@ function removeSnapshot() {
 			$('.show-serial').slideToggle('slow');
 			$.cookie('SNAP-root-view', $('.root-switch').is(':checked') ? 'true' : 'false', { expires: 3650, path:'/' });
 			snap_view(tab_snaps);
-			});
-
-		
+		});
 
 		addButtonTab('<a style="cursor:pointer;" title="<?=_("Switch Off to Hide Docker");?>"><input type="checkbox" class="docker-switch" id="docker-swt"></a>',
 								 "<?=_('BTRFS Volumes');?>");
@@ -561,9 +564,20 @@ function removeSnapshot() {
 			$('.show-docker').slideToggle('slow');
 			$.cookie('SNAP-docker-view', $('.docker-switch').is(':checked') ? 'true' : 'false', { expires: 3650, path:'/' });
 			snap_view(tab_snaps);
-			});
-
 		});
+
+		addButtonTab('<a style="cursor:pointer;" title="<?=_("Switch Off to Hide Excluded");?>"><input type="checkbox" class="exclude-switch" id="exclude-swt"></a>',
+								 "<?=_('BTRFS Volumes');?>");
+
+		$('.exclude-switch').switchButton({ labels_placement: "left", on_label: "<?=_('Show Excluded');?>", off_label: "<?=_('Show Excluded');?>", checked: $.cookie('SNAP-exclude-view') == 'true'});
+		$('.exclude-switch').change(function()
+		{
+			$('.show-exclude').slideToggle('slow');
+			$.cookie('SNAP-exclude-view', $('.exclude-switch').is(':checked') ? 'true' : 'false', { expires: 3650, path:'/' });
+			snap_view(tab_snaps);
+		});
+
+	});
 
 
 
@@ -572,7 +586,7 @@ function removeSnapshot() {
 
 </script>
 
-_(Snapshots BTRFS)_
+**_(Snapshots BTRFS)_**
 
 <pre><form id="SnapBTRFS" onsubmit="return false"><table id='sv2' class='disk_status snapshot'><tr><td><div class="spinner"></div></td></tr></table></form></pre><br>
 

--- a/source/SnapshotDebug.page
+++ b/source/SnapshotDebug.page
@@ -1,6 +1,7 @@
 Menu="Snapshots"
 Title="Debug"
 icon="fa-file"
+Cond="shell_exec('< /boot/config/plugins/snapshots/snapshots.cfg grep debug | grep true')"
 ---
 <?PHP
 /* Copyright 2020-2020, Simon Fairweather

--- a/source/SnapshotSettings.page
+++ b/source/SnapshotSettings.page
@@ -1,0 +1,23 @@
+Icon="fa-clone"
+Author="dcflachs"
+Title="Snapshots"
+Type="xmenu"
+Menu="Utilities"
+---
+<?php 
+$sName = "snapshots";
+$cfg = parse_plugin_cfg($sName);
+?>
+
+<form markdown="1" name="snapshot_plugin_settings" method="POST" action="/update.php" target="progressFrame">
+<input type="hidden" name="#file" value="<?=$sName?>/<?=$sName?>.cfg">
+
+_(Show debug page)_:
+: <select name="debug">
+  <?=mk_option($cfg['debug'], "false", _("Hide"))?>
+  <?=mk_option($cfg['debug'], "true", _("Show"))?>
+  </select>
+
+<input type="submit" name="#default" value="_(Default)_">
+: <input type="submit" name="#apply" value="_(Apply)_" disabled><input type="button" value="_(Done)_" onclick="done()">
+</form>

--- a/source/SnapshotSettings.page
+++ b/source/SnapshotSettings.page
@@ -12,6 +12,17 @@ $cfg = parse_plugin_cfg($sName);
 <form markdown="1" name="snapshot_plugin_settings" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#file" value="<?=$sName?>/<?=$sName?>.cfg">
 
+_(Excluded volumes by path)_:
+<!-- : <span style="margin:0 8px 0 20px;font-weight:bold">_(Excluded folders)_:</span> -->
+: <input type="text" name="exclude" value="<?=$cfg['exclude']?>" class="narrow">
+  <span class="fa fa-question-circle fa-fw" onclick="HelpButton();return false;"></span>
+
+<blockquote class="inline_help" style="display: none;">
+Use to exclude folders from the snapshots interface. Multiple exclusions are separated by a comma.<br>
+Examples are paths, e.g. <strong>`/mnt/disk1/.snapshots/`</strong>, folder names, e.g. <strong>`backups`</strong>, 
+and partial paths, e.g. <strong>`backup/disk`</strong>.
+</blockquote>
+
 _(Show debug page)_:
 : <select name="debug">
   <?=mk_option($cfg['debug'], "false", _("Hide"))?>

--- a/source/include/snapshots.php
+++ b/source/include/snapshots.php
@@ -53,6 +53,7 @@ case 'sv2':
    $urlpath    =  $_GET['path'] ;
    $hideroot = $_POST['hideroot']=="true" ? false : true ;
    $hidedocker = $_POST['hidedocker']=="true" ? false : true ;
+   $hideexcluded = $_POST['hideexcluded']=="true" ? false : true ;
 
    $config_file = $GLOBALS["paths"]["subvol_settings"];
 	$volsettings = @parse_ini_file($config_file, true);
@@ -63,7 +64,7 @@ case 'sv2':
    echo "<tbody><tr>";
    exec(' df -t btrfs --output="target" ',$targetcli);
    $i=1 ;
-   $list=build_list3($targetcli,$hideroot,$hidedocker) ;
+   $list=build_list3($targetcli,$hideroot,$hidedocker,$hideexcluded) ;
             
             
    $ct = "<td title='"._("Remove Device configuration")."'><a style='color:#CC0000;font-weight:bold;cursor:pointer;'  onclick='Create Subvolume(\"{$key}\")'><i class='fa fa-remove hdd'></a>";


### PR DESCRIPTION
This adds the ability to specify exclude paths for the snapshots plugin. This would allow the user to exclude subvolumes and snapshots other than just those associated with docker.

Additionally I added an option to hide the Debug tab.

This patch set only makes changes for the BTRFS pages as I dont have a ZFS file system and i didnt want to make changes that i could not test locally.  

@SimonFair 