### PR TITLE
fix: make btrfs toggles reappear again on Unraid 7.x

### DIFF
--- a/source/SnapshotBTRFS.page
+++ b/source/SnapshotBTRFS.page
@@ -308,9 +308,12 @@ function removeSnapshot() {
 
 	function get_tab_title_by_name(name) {
 		var tab		= $("input[name$=tabs] + label").filter(function(){return $(this).text() === name;}).prev();
+		var btab	= $('button[role="tab"]'		).filter(function(){return $(this).text().trim() === name;});
 		var title	= $("div#title > span.left"		).filter(function(){return $(this).text() === name;}).parent();
 		if (tab.length) {
 			return tab
+		} else if (btab.length) {
+			return btab
 		} else if (title.length) {
 			return title
 		} else {
@@ -374,6 +377,39 @@ function removeSnapshot() {
 					$(this).bind({click:function()
 					{
 						$('#'+elementId).fadeOut('slow');}
+					});
+				}
+			});
+		}
+		else if (Target.prop('nodeName') === "BUTTON")
+		{
+			element.css("display","none");
+
+			if (Append)
+			{
+				$('.tabs').append(element);
+			}
+			else
+			{
+				$('.tabs').prepend(element);
+			}
+
+			Target.on('click', function()
+			{
+				$('#'+elementId).fadeIn('slow');
+			});
+
+			if (Target.attr('aria-selected') === 'true' || ! autoHide) {
+				$('#'+elementId).fadeIn('slow');
+			}
+
+			$('button[role="tab"]').each(function()
+			{
+				if (! $(this).is(Target) && autoHide)
+				{
+					$(this).on('click', function()
+					{
+						$('#'+elementId).fadeOut('slow');
 					});
 				}
 			});

--- a/source/SnapshotZFS.page
+++ b/source/SnapshotZFS.page
@@ -324,9 +324,12 @@ $('#zs1').load('/plugins/snapshots/include/snapshots.php',{table:'zs1'});
 
 	function get_tab_title_by_name(name) {
 		var tab		= $("input[name$=tabs] + label").filter(function(){return $(this).text() === name;}).prev();
+		var btab	= $('button[role="tab"]'		).filter(function(){return $(this).text().trim() === name;});
 		var title	= $("div#title > span.left"		).filter(function(){return $(this).text() === name;}).parent();
 		if (tab.length) {
 			return tab
+		} else if (btab.length) {
+			return btab
 		} else if (title.length) {
 			return title
 		} else {
@@ -390,6 +393,39 @@ $('#zs1').load('/plugins/snapshots/include/snapshots.php',{table:'zs1'});
 					$(this).bind({click:function()
 					{
 						$('#'+elementId).fadeOut('slow');}
+					});
+				}
+			});
+		}
+		else if (Target.prop('nodeName') === "BUTTON")
+		{
+			element.css("display","none");
+
+			if (Append)
+			{
+				$('.tabs').append(element);
+			}
+			else
+			{
+				$('.tabs').prepend(element);
+			}
+
+			Target.on('click', function()
+			{
+				$('#'+elementId).fadeIn('slow');
+			});
+
+			if (Target.attr('aria-selected') === 'true' || ! autoHide) {
+				$('#'+elementId).fadeIn('slow');
+			}
+
+			$('button[role="tab"]').each(function()
+			{
+				if (! $(this).is(Target) && autoHide)
+				{
+					$(this).on('click', function()
+					{
+						$('#'+elementId).fadeOut('slow');
 					});
 				}
 			});

--- a/source/include/lib.php
+++ b/source/include/lib.php
@@ -503,16 +503,19 @@ function process_subvolumes3($btrfs_list,$line, $uuid, $hidedocker=false,$hideex
 	
 				$subvol = $uuid[$arrMatch['puuid']] ;
 				$ruuid =  $arrMatch['ruuid'] ;
-				if ($subvol == NULL) $subvol = "~NONE" ; 
+				if ($subvol == NULL) $subvol = "~NONE" ;
 				if ($ruuid != "-" ) {
 					$incremental = $subvol ;
 					$subvol = "~INCREMENTAL" ;
 					$btrfs_list[$line][$subvol]["short_vol"] = $subvol ;
 				} else { $incremental = NULL ;}
-	
-			
-				
-				 $btrfs_list[$line][$subvol]["subvolume"][$arrMatch["path"]] = [		
+
+				/* Skip if the parent subvol entry was not built (e.g. root subvol hidden by hideroot=true).
+				   Otherwise auto-vivification creates a stub without short_vol/vol/path, which the renderer
+				   turns into a broken "SubVolume: /" row. */
+				if ($subvol[0] === '/' && !isset($btrfs_list[$line][$subvol])) continue ;
+
+				 $btrfs_list[$line][$subvol]["subvolume"][$arrMatch["path"]] = [
 				'uuid' =>$arrMatch['uuid'],
 				'puuid' =>$arrMatch['puuid'],
 				'ruuid' => $arrMatch['ruuid'],


### PR DESCRIPTION
- due to changes in page structure btrfs visibility toggles (show root, etc.) were not rendered anymore. Adapt to new page structure
- add additional guard to hide broken root snapshots configs if switch is off